### PR TITLE
.gitignoreにClaude Codeの設定ファイルを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ Pipfile.lock
 
 # Logs
 *.log
+
+# Claude Code
+.claude


### PR DESCRIPTION
## 概要
.gitignoreファイルに`.claude`ディレクトリを追加しました。

## 変更内容
- Claude Codeの設定ファイル（`.claude`）をgitの追跡対象から除外

## 理由
Claude Codeはローカル設定ファイルを`.claude`ディレクトリに保存するため、このディレクトリをリポジトリにコミットする必要がありません。

🤖 Generated with [Claude Code](https://claude.ai/code)